### PR TITLE
Swift 1.2 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,16 @@ All of the examples in this README and others can be found in the library's test
 
 Set `Stepwise.StepDebugLoggingEnabled` to `true` to get log messages of what's happening in your steps.
 
+### Swift Versions
+
+Stepwise uses Swift 1.2. The following table tracks older Swift versions and the corresponding git tag to use for that version.
+
+Swift Version | Tag
+------------- | ---
+1.0 | swift-1.1
+1.1 | swift-1.1
+
+
 ### License
 
     Copyright (c) 2014, Webs <kevin@webs.com>

--- a/Stepwise.swift
+++ b/Stepwise.swift
@@ -64,7 +64,7 @@ public func toStep<InputType, OutputType>(inQueue: dispatch_queue_t!, body: (Ste
 /// :param: body The body of the step, which takes InputType as input and outputs OutputType.
 /// :returns: A StepChain object. Can be extended with then() and started with start().
 public func toStep<InputType, OutputType>(named: String?, inQueue: dispatch_queue_t!, body: (Step<InputType, OutputType>) -> ()) -> StepChain<InputType, OutputType, InputType, OutputType> {
-    let step = StepNode<InputType, OutputType>(name: named, queue: inQueue, body)
+    let step = StepNode<InputType, OutputType>(name: named, queue: inQueue, body: body)
     return StepChain(step, step)
 }
 
@@ -95,7 +95,7 @@ public class StepChain<StartInputType, StartOutputType, CurrentInputType, Curren
     /// :param: body The body of the step, which takes InputType as input and outputs OutputType.
     /// :returns: A new StepChain that ends in the added step. Can be extended with then() and started with start().
     public func then<NextOutputType>(name: String? = nil, queue: dispatch_queue_t! = DefaultStepQueue, body: (Step<CurrentOutputType, NextOutputType>) -> ()) -> StepChain<StartInputType, StartOutputType, CurrentOutputType, NextOutputType> {
-        let step = StepNode<CurrentOutputType, NextOutputType>(name: name, queue: queue, body)
+        let step = StepNode<CurrentOutputType, NextOutputType>(name: name, queue: queue, body: body)
         return then(step)
     }
     

--- a/StepwiseTests/StepwiseTests.swift
+++ b/StepwiseTests/StepwiseTests.swift
@@ -43,7 +43,7 @@ class StepwiseTests: XCTestCase {
         
         chain.start(2)
         
-        waitForExpectationsWithTimeout(5, nil)
+        waitForExpectationsWithTimeout(5, handler: nil)
     }
     
     func testChaining() {
@@ -106,7 +106,7 @@ class StepwiseTests: XCTestCase {
         }
         chain3.start(1)
         
-        waitForExpectationsWithTimeout(5, nil)
+        waitForExpectationsWithTimeout(5, handler: nil)
     }
     
     func testCustomStepQueue() {
@@ -123,7 +123,7 @@ class StepwiseTests: XCTestCase {
             }
         }.start()
         
-        waitForExpectationsWithTimeout(5, nil)
+        waitForExpectationsWithTimeout(5, handler: nil)
     }
     
     func testStepError() {
@@ -137,7 +137,7 @@ class StepwiseTests: XCTestCase {
         
         errorStep.start()
         
-        waitForExpectationsWithTimeout(5, nil)
+        waitForExpectationsWithTimeout(5, handler: nil)
     }
     
     func testChainErrorFirstStep() {
@@ -154,7 +154,7 @@ class StepwiseTests: XCTestCase {
         
         chain.start()
         
-        waitForExpectationsWithTimeout(5, nil)
+        waitForExpectationsWithTimeout(5, handler: nil)
     }
     
     func testChainErrorLaterStep() {
@@ -172,7 +172,7 @@ class StepwiseTests: XCTestCase {
         
         chain.start()
         
-        waitForExpectationsWithTimeout(5, nil)
+        waitForExpectationsWithTimeout(5, handler: nil)
     }
     
     func testSingleStepFinally() {
@@ -345,7 +345,7 @@ class StepwiseTests: XCTestCase {
             cancelExpectation.fulfill()
         }
         
-        waitForExpectationsWithTimeout(5, nil)
+        waitForExpectationsWithTimeout(5, handler: nil)
     }
     
     func testFinallyChainCancellation() {
@@ -381,7 +381,7 @@ class StepwiseTests: XCTestCase {
             XCTAssertEqual(token.reason!, "Cancelling for a really good reason.", "Cancellation reason should match one given.")
         }
         
-        waitForExpectationsWithTimeout(10, nil)
+        waitForExpectationsWithTimeout(10, handler: nil)
     }
     
     func testStepCancellation() {
@@ -403,7 +403,7 @@ class StepwiseTests: XCTestCase {
             expectation.fulfill()
         }
         
-        waitForExpectationsWithTimeout(5, nil)
+        waitForExpectationsWithTimeout(5, handler: nil)
     }
     
     func testChainCancellation() {
@@ -431,7 +431,7 @@ class StepwiseTests: XCTestCase {
             XCTAssertEqual(token.reason!, "Cancelling for a really good reason.", "Cancellation reason should match one given.")
         }
         
-        waitForExpectationsWithTimeout(10, nil)
+        waitForExpectationsWithTimeout(10, handler: nil)
     }
     
     func testDocumentationExamples() {
@@ -491,7 +491,7 @@ class StepwiseTests: XCTestCase {
         }.then { (step : Step<String, Int>) in
             // This never executes.
             println("I never execute!")
-            step.resolve(countElements(step.input))
+            step.resolve(count(step.input))
         }.onError { error in
             example2Expectation.fulfill()
         }.start()
@@ -560,7 +560,7 @@ class StepwiseTests: XCTestCase {
             // Handle error here...
         }.finally { resultState in
             // In our test we'll first verify the written bytes, then actually close the stream like in the example.
-            let bytesWritten = outputStream.propertyForKey(NSStreamDataWrittenToMemoryStreamKey) as NSData
+            let bytesWritten = outputStream.propertyForKey(NSStreamDataWrittenToMemoryStreamKey) as! NSData
             let testData = NSData(contentsOfURL: someDataURL)!
             XCTAssertTrue(bytesWritten.isEqualToData(testData), "Bytes written to output stream should match fetched image bytes.")
             
@@ -571,7 +571,7 @@ class StepwiseTests: XCTestCase {
         }.start()
         
         // Wait for all documentation expectations.
-        waitForExpectationsWithTimeout(10, nil)
+        waitForExpectationsWithTimeout(10, handler: nil)
     }
 }
 


### PR DESCRIPTION
Use branch `swift-1.2` for Xcode 6.3 support. When 6.3 comes out of beta this PR will be merged.