### PR TITLE
Swift 2.0 Support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014, Webs <kevin@webs.com>
+Copyright (c) 2014-2015, Webs <kevin@webs.com>
 
 Permission to use, copy, modify, and/or distribute this software for any
     purpose with or without fee is hereby granted, provided that the above

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Stepwise
 
-*NOTE:* Stepwise 2.0, the Swift 2 overhaul, is still in beta and may change. Please open an [issue](https://github.com/websdotcom/Stepwise/issues) if you have questions or suggestions on how the 2.0 API should look/work.
-
 Stepwise is a Swift framework for executing a series of steps asynchronously. Steps are just closures that take an input and return an output. Outputs are passed as inputs to the next step in the chain. A chain of steps is cancelable and handles errors. Here's a totally contrived example of steps to fetch an image from the Internet and shrink it by half:
 
 ```swift

--- a/README.md
+++ b/README.md
@@ -1,28 +1,20 @@
 # Stepwise
 
-Stepwise is a Swift framework for executing a series of steps asynchronously. Steps are single-dependency and cancelable. `Step` objects wrap your closures; they're genericized so you get strongly-typed inputs and outputs. Here's a totally contrived example of steps to fetch an image from the Internet and shrink it by half:
+*NOTE:* Stepwise 2.0, the Swift 2 overhaul, is still in beta and may change. Please open an [issue](https://github.com/websdotcom/Stepwise/issues) if you have questions or suggestions on how the 2.0 API should look/work.
+
+Stepwise is a Swift framework for executing a series of steps asynchronously. Steps are just closures that take an input and return an output. Outputs are passed as inputs to the next step in the chain. A chain of steps is cancelable and handles errors. Here's a totally contrived example of steps to fetch an image from the Internet and shrink it by half:
 
 ```swift
-let fetchAndResizeImageSteps = toStep { (step: Step<NSURL, UIImage>) in
-    // This is the url we pass into the step chain
-    let url = step.input
-    
-    // Fetch the image data. Obviously we'd be using Alamofire or something irl.
-    if let imageData = NSData(contentsOfURL: url) {
-        // Create the image
-        let image = UIImage(data: imageData)!
-        
-        // Pass it to the next step
-        step.resolve(image)
+let fetchAndResizeImage = toStep { (url : NSURL) -> UIImage in
+    // Fetch the image and create it. Obviously we'd be using Alamofire or something irl.
+    guard let imageData = NSData(contentsOfURL: url), image = UIImage(data: imageData) else {
+        throw NSError(domain: "com.my.domain", code: -1, userInfo: nil)
     }
-    else {
-        // Oh no! Something went wrong!
-        step.error(NSError(domain: "com.my.domain", code: -1, userInfo: nil))
-    }
-}.then { (step: Step<UIImage, UIImage>) in
-    // Grab the fetched image
-    let image = step.input
     
+    // Pass it to the next step
+    return image
+
+}.then { (image : UIImage) -> UIImage in
     // Resize it
     let targetSize = CGSize(width: image.size.width / 2.0, height: image.size.height / 2.0)
     UIGraphicsBeginImageContextWithOptions(targetSize, true, 0.0)
@@ -31,57 +23,51 @@ let fetchAndResizeImageSteps = toStep { (step: Step<NSURL, UIImage>) in
     UIGraphicsEndImageContext()
     
     // Return it
-    step.resolve(resizedImage)
-}.then { (step: Step<UIImage, Void>) in
-    // Get fetched, resized image
-    let image = step.input
-    
+    return resizedImage
+}.then { image in
     // Do something with image here.
-    // Set it to a shared variable, pass it to another step, etc.
-    step.resolve()
+    // Set it on a view, pass it to another step, etc.
 }
 
-// Having set up the chain of steps, pass in a URL to get fetching.
+// Having set up the chain of steps, pass in a URL to get fetching. You can also do this one the chain directly by just following up the final `then { }` with `.start(...)`. 
 let importantImageURL = NSURL(string: "http://i1.kym-cdn.com/entries/icons/original/000/000/774/lime-cat.jpg")!
-fetchAndResizeImageSteps.start(importantImageURL)
+fetchAndResizeImage.start(importantImageURL)
 ```
 
-The first step, created by the `toStep` function, accepts a closure with a single step parameter. The step parameter is of type `Step<NSURL, UIImage>`, so it accepts an `NSURL` as input and outputs a `UIImage` if successful. The first step fetches the data from the URL and tries to create an image from it. If it fails the step results in an error and calls `step.error()`. If all is well the step resolves by calling `step.resolve(image)`.
+The first step, created by the `toStep` function, accepts a closure (or function) with a single input parameter. The input parameter is of type `NSURL` and outputs a `UIImage` if successful. The first step fetches the data from the URL and tries to create an image from it. If it fails the step throws an error. If all is well the step resolves by calling `return image`.
 
 When a step resolves successfully it passes its output as input to the next step, which is created by calling `then()`. In this example the second step resizes the image to half-size, then resolves with it. There is no error case.
 
-The third step, also enqueued with `then()`, is just an example of a step with a `Void` output. Steps with `Void` outputs may call `resolve()` without an argument, just as steps with `Void` inputs may call `start()` without an argument.
+The third step, also enqueued with `then()`, is just an example of a step with a `Void` output. Steps with `Void` outputs don't need to `return` anything, just as steps with `Void` inputs don't need to declare an input at the start of the closure.
 
 ### Errors
 
-In the example above there is no error handler for the `error()` in the first step, but a handler can be added at any point in the chain by calling `onError()`. `onError()` accepts a simple closure with an `NSError` parameter and allows your code to react to errors generated by steps. Here's a quick example:
+In the example above there is no error handler for the `throw` in the first step, but a handler can be added at any point in the chain by calling `onError()`. `onError()` accepts a simple closure with an `ErrorType` parameter and allows your code to react to errors generated by steps. Here's a quick example:
 
 ```swift
 // prints "ERROR: Error in step 1!"
-toStep { (step: Step<Void, String>) in
-    step.error(NSError(domain: "com.my.domain", code: -1, userInfo: [NSLocalizedDescriptionKey : "Error in step 1!"]))
-}.then { (step : Step<String, Int>) in
+toStep { () -> String in
+    throw NSError(domain: "com.my.domain", code: -1, userInfo: [NSLocalizedDescriptionKey : "Error in step 1!"])
+}.then { (input : String) -> Int in
     // This never executes.
-    println("I never execute!")
-    step.resolve(countElements(step.input))
+    print("I never execute!")
+    return input.characters.count
 }.onError { error in
-    println("ERROR: \(error.localizedDescription)")
+    print("ERROR: \((error as NSError).localizedDescription)")
 }.start()
 ```
 
-An important limitation to note is that, at present, a chain of steps can only have a single error handler. You can multiplex responses to errors in the handler by erroring with different domains, codes, or userInfos per step.
+An important limitation to note is that, at present, a chain of steps can only have a single error handler. You can multiplex responses to errors in the handler by checking the result of conditional casts against `error`.
 
 ### Cancellation
 
-Cancellation is baked right into Stepwise. Every step chain has a `cancellationToken` property that returns a `CancellationToken` object. This object provides a single method, `cancel()`, which cancels any step that has this token. Every step in a chain will consult the token before and during execution to see if it has been canceled. Here's an example:
+Cancellation is baked into Stepwise. Every step chain has a `cancellationToken` property that returns a `CancellationToken` object. This object provides a single method, `cancel()`, which cancels any step that has this token. Every step in a chain will consult the token before and during execution to see if it has been canceled. Here's an example:
 
 ```swift
-let willCancelStep = toStep { (step: Step<Void, String>) in
+let willCancelStep = toStep { () -> String in
     // Will never execute.
     step.resolve("some result")
-}
-
-willCancelStep.start()
+}.start()
 
 // Grab the step's token and cancel it.
 let token = willCancelStep.cancellationToken
@@ -100,31 +86,25 @@ Each chain also provides a `finally` method which you can call to attach a handl
 let outputStream : NSOutputStream = ...
 let someDataURL : NSURL = ...
 
-toStep { (step : Step<Void, NSData>) in
-    if let someData = NSData(contentsOfURL: someDataURL) {
-        step.resolve(someData)
+toStep { () -> NSData in
+    guard let someData = NSData(contentsOfURL: someDataURL) else {
+        throw NSError(domain: "com.my.domain.fetch-data", code: -1, userInfo: nil)
     }
-    else {
-        step.error(NSError(domain: "com.my.domain.fetch-data", code: -1, userInfo: nil))
-    }
-}.then { (step: Step<NSData, Void>) in
+    return someData
+}.then { data in
     // Write our data
-    let data = step.input
     var bytes = UnsafePointer<UInt8>(data.bytes)
     var bytesRemaining = data.length
 
     while bytesRemaining > 0 {
         let written = outputStream.write(bytes, maxLength: bytesRemaining)
         if written == -1 {
-            step.error(NSError(domain: "com.my.domain.write-data", code: -1, userInfo: nil))
-            return
+            throw NSError(domain: "com.my.domain.write-data", code: -1, userInfo: nil)
         }
 
         bytesRemaining -= written
         bytes += written
     }
-
-    step.resolve()
 }.onError { error in
     // Handle error here...
 }.finally { resultState in
@@ -132,6 +112,37 @@ toStep { (step : Step<Void, NSData>) in
     outputStream.close()
 }.start()
 ```
+
+### A Note on Closure Signatures
+
+Sometimes Xcode can't guess the input and output types based on what's happening inside a step closure. This is especially true if you save the steps to a variable and `start` it later. When you get type errors, help poor Xcode out by adding a signature to the start of the closure, like this (from example #1 above):
+
+```swift
+let fetchAndResizeImage = toStep { (url : NSURL) -> UIImage in
+    // Let's not repeat ourselves
+}
+
+// Start the chain
+fetchAndResizeImage.start(url)
+```
+
+A closure that takes a `Void` and returns a `Void` would be
+
+```swift
+toStep { () -> Void in
+    // Gaze into the void
+}.start()
+```
+
+### Installing
+
+Use Cocoapods!
+
+    $ gem install cocoapods
+
+if you don't have it, then in your Podfile:
+
+    pod 'Stepwise', '~> 2.0'
 
 ### Tests
 
@@ -143,17 +154,19 @@ Set `Stepwise.StepDebugLoggingEnabled` to `true` to get log messages of what's h
 
 ### Swift Versions
 
-Stepwise uses Swift 1.2. The following table tracks older Swift versions and the corresponding git tag to use for that version.
+Stepwise uses Swift 2.0. The following table tracks older Swift versions and the corresponding git tag to use for that version.
 
 Swift Version | Tag
 ------------- | ---
 1.0 | swift-1.1
 1.1 | swift-1.1
+1.2 | swift-1.2
+2.0 | 2.0
 
 
 ### License
 
-    Copyright (c) 2014, Webs <kevin@webs.com>
+    Copyright (c) 2014-2015, Webs <kevin@webs.com>
 
     Permission to use, copy, modify, and/or distribute this software for any
     purpose with or without fee is hereby granted, provided that the above

--- a/Stepwise.podspec
+++ b/Stepwise.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Stepwise"
-  s.version      = "1.0"
+  s.version      = "2.0-beta1"
   s.summary      = "Serial, cancelable, generic, asynchronous tasks in Swift."
   s.description  = "Stepwise is a framework for creating a series of steps quickly and easily. Every step can take a single input and have a single output, and steps can depend on each other to build chains and pass outputs down the chain."
   s.homepage     = "https://github.com/websdotcom/Stepwise"

--- a/Stepwise.podspec
+++ b/Stepwise.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Stepwise"
-  s.version      = "2.0-beta1"
+  s.version      = "2.0-beta2"
   s.summary      = "Serial, cancelable, generic, asynchronous tasks in Swift."
   s.description  = "Stepwise is a framework for creating a series of steps quickly and easily. Every step can take a single input and have a single output, and steps can depend on each other to build chains and pass outputs down the chain."
   s.homepage     = "https://github.com/websdotcom/Stepwise"

--- a/Stepwise.swift
+++ b/Stepwise.swift
@@ -18,6 +18,8 @@
 
 import Foundation
 
+// TODO: Function to convert a throwing function with a single return value into a step.
+    // Throwing = failure, returning = resolution
 // TODO: Once/if we can specialize generic top-level functions, consider a new DSL syntax.
 
 public var StepDebugLoggingEnabled = false

--- a/Stepwise.xcodeproj/project.pbxproj
+++ b/Stepwise.xcodeproj/project.pbxproj
@@ -164,7 +164,9 @@
 		0A3A28271A375D6E000A368D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0610;
+				LastSwiftMigration = 0700;
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = Pagemodo;
 				TargetAttributes = {
 					0A3A282F1A375D6E000A368D = {
@@ -260,6 +262,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -335,6 +338,7 @@
 				INFOPLIST_FILE = Stepwise/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.pagemodo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -352,6 +356,7 @@
 				INFOPLIST_FILE = Stepwise/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.pagemodo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 			};
@@ -370,6 +375,7 @@
 				);
 				INFOPLIST_FILE = StepwiseTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.pagemodo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -383,6 +389,7 @@
 				);
 				INFOPLIST_FILE = StepwiseTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.pagemodo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -406,6 +413,7 @@
 				0A3A28481A375D6E000A368D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		0A3A28491A375D6E000A368D /* Build configuration list for PBXNativeTarget "StepwiseTests" */ = {
 			isa = XCConfigurationList;
@@ -414,6 +422,7 @@
 				0A3A284B1A375D6E000A368D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Stepwise/Info.plist
+++ b/Stepwise/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.pagemodo.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/StepwiseTests/Info.plist
+++ b/StepwiseTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.pagemodo.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/StepwiseTests/StepwiseTests.swift
+++ b/StepwiseTests/StepwiseTests.swift
@@ -336,7 +336,7 @@ class StepwiseTests: XCTestCase {
         
         let token = willCancelStep.cancellationToken
         willCancelStep.start()
-        token.cancel(reason: "Cancelling for a really good reason.")
+        token.cancel("Cancelling for a really good reason.")
         
         let cancelExpectation = expectationWithDescription("Waiting for cancel to take effect.")
         after(1.0) {
@@ -372,7 +372,7 @@ class StepwiseTests: XCTestCase {
         
         let cancelExpectation = expectationWithDescription("Waiting for cancel to take effect.")
         after(3.0) {
-            let result = token.cancel(reason: "Cancelling for a really good reason.")
+            token.cancel("Cancelling for a really good reason.")
         }
         after(7.0) {
             if didCancel {
@@ -394,7 +394,7 @@ class StepwiseTests: XCTestCase {
         
         let token = willCancelStep.cancellationToken
         willCancelStep.start()
-        token.cancel(reason: "Cancelling for a really good reason.")
+        token.cancel("Cancelling for a really good reason.")
         
         let expectation = expectationWithDescription("Waiting for cancel to take effect.")
         after(1.0) {
@@ -422,7 +422,7 @@ class StepwiseTests: XCTestCase {
         
         let expectation = expectationWithDescription("Waiting for cancel to take effect.")
         after(3.0) {
-            let result = token.cancel(reason: "Cancelling for a really good reason.")
+            token.cancel("Cancelling for a really good reason.")
         }
         after(7.0) {
             if didCancel {
@@ -480,7 +480,7 @@ class StepwiseTests: XCTestCase {
         }
         
         let limecatFileURL = NSBundle(forClass: StepwiseTests.self).pathForResource("lime-cat", ofType: "jpg")!
-        let importantImageURL = NSURL(fileURLWithPath: limecatFileURL)!
+        let importantImageURL = NSURL(fileURLWithPath: limecatFileURL)
         fetchAndResizeImageSteps.start(importantImageURL)
         
         // MARK: Example 2
@@ -490,8 +490,8 @@ class StepwiseTests: XCTestCase {
             step.error(NSError(domain: "com.my.domain", code: -1, userInfo: [NSLocalizedDescriptionKey : "Error in step 1!"]))
         }.then { (step : Step<String, Int>) in
             // This never executes.
-            println("I never execute!")
-            step.resolve(count(step.input))
+            print("I never execute!")
+            step.resolve(step.input.characters.count)
         }.onError { error in
             example2Expectation.fulfill()
         }.start()
@@ -510,7 +510,7 @@ class StepwiseTests: XCTestCase {
         
         // Grab the step's token and cancel it.
         let token = willCancelStep.cancellationToken
-        token.cancel(reason: "Cancelling for a really good reason.")
+        token.cancel("Cancelling for a really good reason.")
         
         // Test that cancellation happened
         after(1.0) {
@@ -527,7 +527,7 @@ class StepwiseTests: XCTestCase {
         let example4Expectation = expectationWithDescription("Documentation example 4. Using finally() blocks.")
         let outputStream : NSOutputStream = NSOutputStream(toMemory: ())
         outputStream.open()
-        let someDataURL : NSURL = NSURL(fileURLWithPath: NSBundle(forClass: StepwiseTests.self).pathForResource("lime-cat", ofType: "jpg")!)!
+        let someDataURL : NSURL = NSURL(fileURLWithPath: NSBundle(forClass: StepwiseTests.self).pathForResource("lime-cat", ofType: "jpg")!)
             
         toStep { (step : Step<Void, NSData>) in
             if let someData = NSData(contentsOfURL: someDataURL) {

--- a/StepwiseTests/StepwiseTests.swift
+++ b/StepwiseTests/StepwiseTests.swift
@@ -31,9 +31,9 @@ class StepwiseTests: XCTestCase {
     func testDSL() {
         let expectation = expectationWithDescription("Chain creates a string from a number.")
         
-        let chain = toStep { (step : Step<Int, Int>) in
+        let chain = toStep { step in
             step.resolve(step.input + 1)
-        }.then { (step : Step<Int, String>) in
+        }.then { step in
             step.resolve("\(step.input)")
         }.then { (step : Step<String, Void>) in
             XCTAssertEqual(step.input, "3", "Assuming 2, chain adds 1, then transforms to string.")


### PR DESCRIPTION
Update Stepwise for Swift 2. Major, API-breaking changes:

* Step closures no longer take a single `Step` argument. Instead they take the actual step input, which can be any type.
* The `step.resolve()` method has been replaced with a simple `return` from the closure body.
* The `step.error()` method has been replaced with a `throw` statement from the closure body.
* The `step.then(chain:)` series of methods has been removed without replacement. Still thinking on how best to handle this with the new syntax, and if it's actually necessary or just complicated and weird.
* Errors passed into the `onError()` handler are now of type `ErrorType`.
* `toStep` now provides cleaner API to convert functions into steps.

See the [README](https://github.com/websdotcom/Stepwise/blob/swift-2.0/README.md) for updated docs and examples.